### PR TITLE
Add extra inventory fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ python src/inventario.py --drive /caminho/do/drive --hash
 Os arquivos CSV serão criados em `saida_inventarios/`. Cada execução gera um log
 em `logs/`.
 
+Cada inventário contém as colunas:
+
+- `caminho` – caminho relativo ao drive
+- `tamanho` – tamanho em bytes
+- `data_modificacao` – última modificação
+- `data_criacao` – data de criação do arquivo
+- `extensao` – extensão em minúsculas (``.jpg``, ``.txt``...)
+- `drive` – origem do inventário
+- `dir_pai` – primeiro diretório logo abaixo do drive
+- `hash_md5` – apenas se a flag `--hash` for utilizada
+
 ### Exemplos por sistema operacional
 
 Windows:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,7 +1,11 @@
 from pathlib import Path
 from typing import Iterator
 import hashlib
-from tqdm import tqdm
+try:
+    from tqdm import tqdm
+except ModuleNotFoundError:  # pragma: no cover - fallback when tqdm não instalado
+    def tqdm(iterable, **kwargs):
+        return iterable
 
 
 def listar_arquivos(diretorio: Path) -> Iterator[Path]:

--- a/tests/test_inventario.py
+++ b/tests/test_inventario.py
@@ -1,0 +1,43 @@
+import csv
+import os
+from pathlib import Path
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from inventario import gerar_inventario  # noqa: E402
+
+
+def test_gerar_inventario_campos(tmp_path):
+    drive = tmp_path / "HD"
+    (drive / "Fotos").mkdir(parents=True)
+    arquivo = drive / "Fotos" / "img.jpg"
+    arquivo.write_text("x")
+
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        gerar_inventario(drive, calcular_hashes=False)
+    finally:
+        os.chdir(cwd)
+
+    csv_path = tmp_path / "saida_inventarios" / f"{drive.name}_inventario.csv"
+    assert csv_path.exists()
+
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        row = next(reader)
+
+    expected_fields = [
+        "caminho",
+        "tamanho",
+        "data_modificacao",
+        "data_criacao",
+        "extensao",
+        "drive",
+        "dir_pai",
+    ]
+    assert reader.fieldnames == expected_fields
+    assert row["extensao"] == ".jpg"
+    assert row["dir_pai"] == "Fotos"
+    assert row["drive"] == str(drive)


### PR DESCRIPTION
## Summary
- include creation date, extension, drive and parent directory in CSV
- fallback to a simple tqdm if module isn't installed
- document new columns in README
- test inventory output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_687e84b25de483249256ad2c5c91e9c6